### PR TITLE
Use SPDX identifier in license field of META.info

### DIFF
--- a/META.info
+++ b/META.info
@@ -1,6 +1,7 @@
 {
     "perl"	  : "6.*",
     "name"	  : "MIME::QuotedPrint",
+    "license" : "CC0-1.0",
     "version"	  : "1.0.0",
     "author"      : "github:retupmoca",
     "description" : "quoted-printable mime encode/decode",


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license